### PR TITLE
Whoops im Backend wenn kein Sortierfeld ausgewählt ist

### DIFF
--- a/lib/structure_plus.php
+++ b/lib/structure_plus.php
@@ -155,6 +155,8 @@ class structure_plus {
                 WHERE ' . $where;
             if ($config['additional_db_column']) {
                 $qry .= ' ORDER BY '.$config['additional_db_column'].' '. $config['order_direction'];
+            } else {
+                $config['additional_db_column'] = 'id';
             }
             if ($config['items_per_page']) {
                 $qry .= ' LIMIT ' . $artPager->getCursor() . ',' . $artPager->getRowsPerPage();

--- a/lib/structure_plus.php
+++ b/lib/structure_plus.php
@@ -152,8 +152,10 @@ class structure_plus {
             $qry = 'SELECT *
                 FROM
                     ' . rex::getTable('article') . '
-                WHERE ' . $where . '
-                ORDER BY '.$config['additional_db_column'].' '. $config['order_direction'];
+                WHERE ' . $where;
+            if ($config['additional_db_column']) {
+                $qry .= ' ORDER BY '.$config['additional_db_column'].' '. $config['order_direction'];
+            }
             if ($config['items_per_page']) {
                 $qry .= ' LIMIT ' . $artPager->getCursor() . ',' . $artPager->getRowsPerPage();
             }


### PR DESCRIPTION
Nach der Installation gibt es einen Whoops im Backend bei der Structure.
Da noch kein Sortierfeld gesetzt ist ist der ORDER BY ungültig.